### PR TITLE
Statisk path for js

### DIFF
--- a/UKMsystem_tools.php
+++ b/UKMsystem_tools.php
@@ -100,13 +100,13 @@ class UKMsystem_tools extends Modul
         if( $_GET['action'] == 'website_clean' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteClean',
-                PLUGIN_PATH . 'UKMsystem_tools/js/website_clean.js'
+                plugin_dir_url(__FILE__) . 'js/website_clean.js'
             );
         }
         if( $_GET['action'] == 'website_create' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteCreate',
-                PLUGIN_PATH . 'UKMsystem_tools/js/website_create.js'
+                plugin_dir_url(__FILE__) . 'js/website_create.js'
             );
         }
     }

--- a/UKMsystem_tools.php
+++ b/UKMsystem_tools.php
@@ -100,13 +100,13 @@ class UKMsystem_tools extends Modul
         if( $_GET['action'] == 'website_clean' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteClean',
-                plugin_dir_url(__FILE__) . 'js/website_clean.js'
+                static::getPluginUrl() . 'js/website_clean.js'
             );
         }
         if( $_GET['action'] == 'website_create' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteCreate',
-                plugin_dir_url(__FILE__) . 'js/website_create.js'
+                static::getPluginUrl() . 'js/website_create.js'
             );
         }
     }

--- a/UKMsystem_tools.php
+++ b/UKMsystem_tools.php
@@ -100,13 +100,13 @@ class UKMsystem_tools extends Modul
         if( $_GET['action'] == 'website_clean' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteClean',
-                plugin_dir_url(__FILE__) . 'js/website_clean.js'
+                PLUGIN_PATH . 'UKMsystem_tools/js/website_clean.js'
             );
         }
         if( $_GET['action'] == 'website_create' ) {
             wp_enqueue_script(
                 'UKMsystem_tools_websiteCreate',
-                plugin_dir_url(__FILE__) . 'js/website_create.js'
+                PLUGIN_PATH . 'UKMsystem_tools/js/website_create.js'
             );
         }
     }


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til:
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"